### PR TITLE
Add ActivitiesSummaries endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 /vendor/
-/.idea/
 composer.lock
 /build
-

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "choccybiccy/humanapi",
+    "name": "iranianpep/humanapi",
     "description": "The easiest way to integrate health data from anywhere.",
     "license": "MIT",
     "keywords": ["humanapi"],

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "iranianpep/humanapi",
+    "name": "choccybiccy/humanapi",
     "description": "The easiest way to integrate health data from anywhere.",
     "license": "MIT",
     "keywords": ["humanapi"],

--- a/docs/endpoints/ActivitiesSummaries.md
+++ b/docs/endpoints/ActivitiesSummaries.md
@@ -1,0 +1,5 @@
+# Activities Summaries
+
+> Get a list of daily activity summaries reported by the data sources.
+
+For more information on the Activities Summaries endpoint see the [official docs](https://reference.humanapi.co/#activity-summaries).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -111,21 +111,22 @@ an `\Choccybiccy\HumanApi\Endpoint\UnsupportedEndpointMethodException` exception
 Here's a complete list of available endpoints that can be queried against, along with the types of data that
 can be retrieved.
 
-| Endpoint                                      | getList | getById | getRecent |
-|-----------------------------------------------|---------|---------|-----------|
-| [Activities](endpoints/Activities.md)       | Yes     | Yes     | Yes       |
-| [BloodGlucose](endpoints/BloodGlucose.md)   | Yes     | Yes     | Yes       |
-| [BloodyOxygen](endpoints/BloodOxygen.md)    | Yes     | Yes     | Yes       |
-| [BloodPressure](endpoints/BloodPressure.md) | Yes     | Yes     | Yes       |
-| [BodyFat](endpoints/BodyFat.md)             | Yes     | Yes     | Yes       |
-| [BodyMassIndex](endpoints/BodyMassIndex.md) | Yes     | Yes     | Yes       |
-| [Genetics](endpoints/Genetics.md)           | Yes     | No      | No        |
-| [HeartRate](endpoints/HeartRate.md)         | Yes     | Yes     | Yes       |
-| [Height](endpoints/Height.md)               | Yes     | Yes     | Yes       |
-| [Locations](endpoints/Locations.md)         | Yes     | Yes     | No        |
-| [Meals](endpoints/Meals.md)                 | Yes     | Yes     | No        |
-| [Profile](endpoints/Profile.md)             | Yes     | No      | No        |
-| [Sleeps](endpoints/Sleeps.md)               | Yes     | Yes     | Yes       |
-| [Sources](endpoints/Sources.md)             | Yes     | No      | No        |
-| [Weight](endpoints/Weight.md)               | Yes     | Yes     | Yes       |
+| Endpoint                                                      | getList | getById | getRecent |
+|---------------------------------------------------------------|---------|---------|-----------|
+| [Activities](endpoints/Activities.md)                         | Yes     | Yes     | Yes       |
+| [ActivitiesSummaries](endpoints/ActivitiesSummaries.md)       | Yes     | Yes     | Yes       |
+| [BloodGlucose](endpoints/BloodGlucose.md)                     | Yes     | Yes     | Yes       |
+| [BloodyOxygen](endpoints/BloodOxygen.md)                      | Yes     | Yes     | Yes       |
+| [BloodPressure](endpoints/BloodPressure.md)                   | Yes     | Yes     | Yes       |
+| [BodyFat](endpoints/BodyFat.md)                               | Yes     | Yes     | Yes       |
+| [BodyMassIndex](endpoints/BodyMassIndex.md)                   | Yes     | Yes     | Yes       |
+| [Genetics](endpoints/Genetics.md)                             | Yes     | No      | No        |
+| [HeartRate](endpoints/HeartRate.md)                           | Yes     | Yes     | Yes       |
+| [Height](endpoints/Height.md)                                 | Yes     | Yes     | Yes       |
+| [Locations](endpoints/Locations.md)                           | Yes     | Yes     | No        |
+| [Meals](endpoints/Meals.md)                                   | Yes     | Yes     | No        |
+| [Profile](endpoints/Profile.md)                               | Yes     | No      | No        |
+| [Sleeps](endpoints/Sleeps.md)                                 | Yes     | Yes     | Yes       |
+| [Sources](endpoints/Sources.md)                               | Yes     | No      | No        |
+| [Weight](endpoints/Weight.md)                                 | Yes     | Yes     | Yes       |
 

--- a/src/HumanApi/Endpoint/ActivitiesSummaries.php
+++ b/src/HumanApi/Endpoint/ActivitiesSummaries.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Choccybiccy\HumanApi\Endpoint;
+
+/**
+ * Class ActivitiesSummaries
+ * @package Choccybiccy\HumanApi\Endpoint
+ */
+class ActivitiesSummaries extends PeriodicEndpoint
+{
+
+    /**
+     * @var string
+     */
+    protected $type = "activities/summaries";
+}


### PR DESCRIPTION
Hi,

These are the following changes:
- `/.idea/` removed to resolve the minor issue at [Sensiolabs](https://insight.sensiolabs.com/projects/85433e4e-842a-4005-99d8-63d95062e380/analyses/22)
- Added `Activities Summaries` along with its documentation

I noticed the old documentation URLs are broken which I probably address in another PR.

Cheers,
Ehsan