### PR TITLE
Upgrade to Guzzle 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: php
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
 before_script: composer install
-script: phpunit
+script: vendor/bin/phpunit
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.6.*"
+        "phpunit/phpunit": "^5.7.21|^6.0"
     },
     "autoload": {
         "psr-4": { "Choccybiccy\\": "src/" }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "guzzlehttp/guzzle": "~5.2"
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*"

--- a/src/HumanApi/Application.php
+++ b/src/HumanApi/Application.php
@@ -86,7 +86,8 @@ class Application extends Api
             )
         );
 
-        return $this->buildCollection($response->json());
+        $responseJson = json_decode($response->getBody(), true);
+        return $this->buildCollection($responseJson);
 
     }
 
@@ -108,7 +109,8 @@ class Application extends Api
             )
         );
 
-        return $this->buildCollection($response->json());
+        $responseJson = json_decode($response->getBody(), true);
+        return $this->buildCollection($responseJson);
 
     }
 
@@ -131,7 +133,8 @@ class Application extends Api
             )
         );
 
-        return new Model($response->json(), $this);
+        $responseJson = json_decode($response->getBody(), true);
+        return new Model($responseJson, $this);
 
     }
 

--- a/src/HumanApi/Auth.php
+++ b/src/HumanApi/Auth.php
@@ -56,6 +56,8 @@ class Auth extends Api
                 "json" => $this->sessionTokenData,
             )
         );
-        return $response->json();
+
+        $responseJson = json_decode($response->getBody(), true);
+        return $responseJson;
     }
 }

--- a/src/HumanApi/Endpoint.php
+++ b/src/HumanApi/Endpoint.php
@@ -118,12 +118,12 @@ abstract class Endpoint extends Api
             )
         );
 
-        $json = $response->json();
+        $responseJson = json_decode($response->getBody(), true);
         if (!$this->listReturnsArray) {
-            $json = array($json);
+            $responseJson = array($responseJson);
         }
 
-        return $this->buildCollection($json);
+        return $this->buildCollection($responseJson);
 
     }
 

--- a/tests/HumanApi/ApplicationTest.php
+++ b/tests/HumanApi/ApplicationTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Traits\ReflectionMethods;
  * Class ApplicationTest
  * @package Choccybiccy\HumanApi
  */
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends \PHPUnit\Framework\TestCase
 {
 
     use ReflectionMethods;
@@ -80,7 +80,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
 
         $application = $this->getMockApplication();
-        $this->setExpectedException('Choccybiccy\HumanApi\Exception\UnsupportedBatchEndpointException');
+        $this->expectException('Choccybiccy\HumanApi\Exception\UnsupportedBatchEndpointException');
         $application->batch("thisEndpointDoesntExist");
 
     }
@@ -212,7 +212,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
      */
     public function testDeleteUserThrowsExceptionWhenWrongErrorCode()
     {
-        $this->setExpectedException('\Choccybiccy\HumanApi\Exception\UnexpectedResponseException');
+        $this->expectException('\Choccybiccy\HumanApi\Exception\UnexpectedResponseException');
         $this->testDeleteUserById(500);
     }
 
@@ -246,7 +246,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
             )
             ->willThrowException($exception);
 
-        $this->setExpectedException('\Choccybiccy\HumanApi\Exception\UnexpectedResponseException');
+        $this->expectException('\Choccybiccy\HumanApi\Exception\UnexpectedResponseException');
         $application->deleteUserById($humanId);
 
     }

--- a/tests/HumanApi/ApplicationTest.php
+++ b/tests/HumanApi/ApplicationTest.php
@@ -48,13 +48,13 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMockResponse($statusCode = 204)
     {
-        $response =  $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
+        $response =  $this->getMockBuilder('Psr\Http\Message\ResponseInterface')
             ->disableOriginalConstructor()
-            ->setMethods(array("json", "getStatusCode", "getReasonPhrase"))
+            ->setMethods(array("getBody", "getStatusCode", "getReasonPhrase"))
             ->getMockForAbstractClass();
         $response->expects($this->any())
-            ->method("json")
-            ->willReturn(array());
+            ->method("getBody")
+            ->willReturn(json_encode(array()));
         $response->expects($this->any())
             ->method("getStatusCode")
             ->willReturn($statusCode);

--- a/tests/HumanApi/AuthTest.php
+++ b/tests/HumanApi/AuthTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Traits\ReflectionMethods;
  * Class AuthTest
  * @package Choccybiccy\HumanApi
  */
-class AuthTest extends \PHPUnit_Framework_TestCase
+class AuthTest extends \PHPUnit\Framework\TestCase
 {
 
     use ReflectionMethods;

--- a/tests/HumanApi/AuthTest.php
+++ b/tests/HumanApi/AuthTest.php
@@ -21,13 +21,13 @@ class AuthTest extends \PHPUnit_Framework_TestCase
      */
     protected function getMockResponse($statusCode = 204)
     {
-        $response =  $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
+        $response =  $this->getMockBuilder('Psr\Http\Message\ResponseInterface')
             ->disableOriginalConstructor()
-            ->setMethods(array("json", "getStatusCode", "getReasonPhrase"))
+            ->setMethods(array("getBody", "getStatusCode", "getReasonPhrase"))
             ->getMockForAbstractClass();
         $response->expects($this->any())
-            ->method("json")
-            ->willReturn(array());
+            ->method("getBody")
+            ->willReturn(json_encode(array()));
         $response->expects($this->any())
             ->method("getStatusCode")
             ->willReturn($statusCode);

--- a/tests/HumanApi/Endpoint/LocationsTest.php
+++ b/tests/HumanApi/Endpoint/LocationsTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Traits\ReflectionMethods;
  * Class LocationsTest
  * @package Choccybiccy\HumanApi\Endpoint
  */
-class LocationsTest extends \PHPUnit_Framework_TestCase
+class LocationsTest extends \PHPUnit\Framework\TestCase
 {
 
     use ReflectionMethods;

--- a/tests/HumanApi/Endpoint/MeasurementEndpointTest.php
+++ b/tests/HumanApi/Endpoint/MeasurementEndpointTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Traits\ReflectionMethods;
  * Class MeasurementEndpointTest
  * @package Choccybiccy\HumanApi\Endpoint
  */
-class MeasurementEndpointTest extends \PHPUnit_Framework_TestCase
+class MeasurementEndpointTest extends \PHPUnit\Framework\TestCase
 {
 
     use ReflectionMethods;

--- a/tests/HumanApi/Endpoint/PeriodicEndpointTest.php
+++ b/tests/HumanApi/Endpoint/PeriodicEndpointTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Traits\ReflectionMethods;
  * Class PeriodicEndpointTest
  * @package Choccybiccy\HumanApi\Endpoint
  */
-class PeriodicEndpointTest extends \PHPUnit_Framework_TestCase
+class PeriodicEndpointTest extends \PHPUnit\Framework\TestCase
 {
 
     use ReflectionMethods;

--- a/tests/HumanApi/Endpoint/SimpleEndpointTest.php
+++ b/tests/HumanApi/Endpoint/SimpleEndpointTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Traits\ReflectionMethods;
  * Class SimpleEndpointTest
  * @package Choccybiccy\HumanApi\Endpoint
  */
-class SimpleEndpointTest extends \PHPUnit_Framework_TestCase
+class SimpleEndpointTest extends \PHPUnit\Framework\TestCase
 {
 
     use ReflectionMethods;
@@ -44,7 +44,7 @@ class SimpleEndpointTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->setExpectedException('Choccybiccy\HumanApi\Exception\UnsupportedEndpointMethodException');
+        $this->expectException('Choccybiccy\HumanApi\Exception\UnsupportedEndpointMethodException');
         $this->runProtectedMethod($simple, "buildSpecificEntryUrl", array(1));
 
     }
@@ -60,7 +60,7 @@ class SimpleEndpointTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()
             ->getMock();
 
-        $this->setExpectedException('Choccybiccy\HumanApi\Exception\UnsupportedEndpointMethodException');
+        $this->expectException('Choccybiccy\HumanApi\Exception\UnsupportedEndpointMethodException');
         $this->runProtectedMethod($simple, "buildRecentUrl", array(1));
 
     }

--- a/tests/HumanApi/EndpointTest.php
+++ b/tests/HumanApi/EndpointTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Traits\ReflectionMethods;
  * Class EndpointTest
  * @package Choccybiccy\HumanApi
  */
-class EndpointTest extends \PHPUnit_Framework_TestCase
+class EndpointTest extends \PHPUnit\Framework\TestCase
 {
 
     use ReflectionMethods;

--- a/tests/HumanApi/EndpointTest.php
+++ b/tests/HumanApi/EndpointTest.php
@@ -156,14 +156,14 @@ class EndpointTest extends \PHPUnit_Framework_TestCase
 
         $result = array("id" => 1, "exampleKey" => "Test");
 
-        $response = $this->getMockBuilder('GuzzleHttp\Message\ResponseInterface')
+        $response = $this->getMockBuilder('Psr\Http\Message\ResponseInterface')
             ->disableOriginalConstructor()
-            ->setMethods(array("json"))
+            ->setMethods(array("getBody"))
             ->getMockForAbstractClass();
 
         $response->expects($this->once())
-            ->method("json")
-            ->willReturn($result);
+            ->method("getBody")
+            ->willReturn(json_encode($result));
 
         $this->setProtectedProperty($endpoint, "method", "get");
         $this->setProtectedProperty($endpoint, "accessToken", $accessToken);

--- a/tests/HumanApi/HumanTest.php
+++ b/tests/HumanApi/HumanTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Human;
  * Class HumanTest
  * @package Choccybiccy\HumanApi
  */
-class HumanTest extends \PHPUnit_Framework_TestCase
+class HumanTest extends \PHPUnit\Framework\TestCase
 {
 
     /**

--- a/tests/HumanApi/ModelTest.php
+++ b/tests/HumanApi/ModelTest.php
@@ -8,7 +8,7 @@ use Choccybiccy\HumanApi\Model;
  * Class ModelTest
  * @package Choccybiccy\HumanApi
  */
-class ModelTest extends \PHPUnit_Framework_TestCase
+class ModelTest extends \PHPUnit\Framework\TestCase
 {
 
     /**


### PR DESCRIPTION
The dependency on Guzzle 5.x prevents this library from being used in projects that use (or have dependencies that use) Guzzle 6.x. In our case, the AWS SDK uses Guzzle 6.x, which posed a problem when trying to use this library.

The only change that needed to be made to support Guzzle 6.x was swapping the `$response->json()` calls for `json_decode($response->getBody(), true)`. This is necessary because Guzzle switched to PSR-7 messages in 6.x, and the PSR-7 ResponseInterface doesn't have a `json()` method.

This PR also fixes unit tests on PHP 7.0. I noticed that you had enabled Travis CI testing on PHP 7.0 and 7.1, but if you look at the job logs for each, the tests weren't being run. Only PHPUnit 6+ runs on PHP 7, and the tests need some modification to work with newer PHPUnit versions.

This also requires a bump in the minimum PHP version, from 5.4 to 5.6. PHP 5.6 is three years old now and the only supported PHP 5 release, so I doubt this is an issue. For any projects that still use Guzzle 5 or PHP 5.4/5.5 and this library, Composer will keep them on the last compatible version.